### PR TITLE
Switch to MetadataExtractor for image metadata handling

### DIFF
--- a/MolenApplicatie.Server/MolenApplicatie.Server.csproj
+++ b/MolenApplicatie.Server/MolenApplicatie.Server.csproj
@@ -15,6 +15,7 @@
 	<ItemGroup>
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.67" />
 		<PackageReference Include="leaflet" Version="0.7.3" />
+		<PackageReference Include="MetadataExtractor" Version="2.8.1" />
 		<PackageReference Include="Microsoft.AspNetCore.SpaProxy">
 			<Version>8.*-*</Version>
 		</PackageReference>


### PR DESCRIPTION
Updated MolenApplicatie.Server.csproj to include MetadataExtractor 2.8.1. Refactored GetDateTakenOfImage.cs to use MetadataExtractor instead of System.Drawing for extracting image metadata. Removed obsolete using directives and added necessary ones for MetadataExtractor. Simplified the GetDateTaken method and improved error handling.