### PR TITLE
Remove unnecessary console.log statements and ngOnInit method

### DIFF
--- a/molenapplicatie.client/src/Services/MapService.ts
+++ b/molenapplicatie.client/src/Services/MapService.ts
@@ -30,12 +30,9 @@ export class MapService {
   updateMarker(tbn: string, molen: MolenData, mapId: string | undefined = undefined) {
     if (!mapId) mapId = this.SelectedMapId;
     var indexOfMap: number = this.maps.findIndex(map => map.MapId == mapId);
-    console.log(indexOfMap)
     if (indexOfMap != -1) {
       var marker = this.maps[indexOfMap].Markers.find(marker => marker.tenBruggeNumber == tbn);
-      console.log(marker)
       if (marker) {
-        console.log("aaaaa")
         marker.marker.remove();
         this.maps[indexOfMap].Markers = this.maps[indexOfMap].Markers.filter(mark => mark.tenBruggeNumber != tbn);
         this.addMarker(molen);

--- a/molenapplicatie.client/src/app/dialogs/molen-dialog/molen-dialog.component.ts
+++ b/molenapplicatie.client/src/app/dialogs/molen-dialog/molen-dialog.component.ts
@@ -61,7 +61,6 @@ export class MolenDialogComponent implements OnDestroy{
       this.molenService.getMolen(this.data.tenBruggeNr).subscribe({
         next: (molen: MolenDataClass) => {
           this.molen = molen;
-          console.log(molen)
           this.molenImages = this.getAllMolenImages();
           this.selectedImage = this.molenImages[0];
         },

--- a/molenapplicatie.client/src/app/map-disappeared-molens/map-disappeared-molens.component.ts
+++ b/molenapplicatie.client/src/app/map-disappeared-molens/map-disappeared-molens.component.ts
@@ -30,7 +30,6 @@ export class MapDisappearedMolensComponent implements AfterViewInit {
       next: (result) => {
         this.molens = result;
         this.mapService.SelectedMapId = this.mapId;
-        console.log(result)
         this.mapService.initMap(result);
       },
       error: (error) => {

--- a/molenapplicatie.client/src/app/map-remainder-molens/map-remainder-molens.component.ts
+++ b/molenapplicatie.client/src/app/map-remainder-molens/map-remainder-molens.component.ts
@@ -23,17 +23,6 @@ export class MapRemainderMolensComponent implements AfterViewInit {
     private mapService: MapService,
     private route: ActivatedRoute) { }
 
-  ngOnInit(): void {
-    this.route.paramMap.subscribe(params => {
-      //this.selectedTenBruggeNumber = params.get('TenBruggeNumber') || '';
-      //if (this.selectedTenBruggeNumber) {
-      //  this.molenService.selectedMolenTenBruggeNumber = this.selectedTenBruggeNumber;
-      //  this.OpenMolenDialog(this.selectedTenBruggeNumber);
-      //}
-      //console.log(params.get('TenBruggeNumber'))
-    });
-  }
-
   getMolens(): void {
     this.molenService.getAllRemainderMolens().subscribe({
       next: (result) => {

--- a/molenapplicatie.client/src/app/open-molen-details/open-molen-details.component.ts
+++ b/molenapplicatie.client/src/app/open-molen-details/open-molen-details.component.ts
@@ -37,7 +37,6 @@ export class OpenMolenDetailsComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe({
       next: (goToMolen: string | undefined) => {
-        console.log(goToMolen)
         this.molenService.removeSelectedMolen();
         if (goToMolen) {
           this.goToMolen(goToMolen);


### PR DESCRIPTION
Removed various console.log statements used for debugging from:
- `updateMarker` method in `MapService.ts`
- `next` callback in `MolenDialogComponent` class in `molen-dialog.component.ts`
- `next` callback in `MapDisappearedMolensComponent` class in `map-disappeared-molens.component.ts`
- `next` callback in `OpenMolenDetailsComponent` class in `open-molen-details.component.ts`

Additionally, removed the `ngOnInit` method and its associated commented-out code and console.log statement from the `MapRemainderMolensComponent` class in `map-remainder-molens.component.ts` as the initialization logic is no longer required.