### PR TITLE
Add async call to fetch Netherlands places in GetAllDataForDB

### DIFF
--- a/MolenApplicatie.Server/Controllers/DBController.cs
+++ b/MolenApplicatie.Server/Controllers/DBController.cs
@@ -21,6 +21,7 @@ namespace MolenApplicatie.Server.Controllers
         [HttpGet("all")]
         public async Task<IActionResult> GetAllDataForDB()
         {
+            await _PlacesService.ReadAllNetherlandsPlaces();
             await _NewMolenDataService.ReadAllMolenTBN();
             await _NewMolenDataService.GetAllMolenData();
             return Ok();


### PR DESCRIPTION
The GetAllDataForDB method in DBController.cs now includes an additional asynchronous call to _PlacesService.ReadAllNetherlandsPlaces() before the existing data retrieval operations. This ensures that place data is loaded as part of the overall data fetching process.